### PR TITLE
Fix environment name typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Usage
 
         $ import gym
         $ import gym_windy_gridworlds
-        $ env = gym.make('WindyGridWorldEnv-v0')  
+        $ env = gym.make('WindyGridWorld-v0')  
 
 ``WindyGridWorld-v0``
 ----------------


### PR DESCRIPTION
Change the environment name in the `README.rst` from `WindyGridWorldEnv-v0`
to `WindyGridWorld-v0`. This is how it is registered in
`gym-windy-gridworlds/__init__.py`, and makes the import work.