### PR TITLE
fixed bug: no class member observation

### DIFF
--- a/gym_windy_gridworlds/envs/king_windy_gridworld_env.py
+++ b/gym_windy_gridworlds/envs/king_windy_gridworld_env.py
@@ -16,6 +16,7 @@ class KingWindyGridWorldEnv(gym.Env):
         self.wind = WIND
         self.start_state = START_STATE
         self.goal_state = GOAL_STATE
+        self.observation = START_STATE
         self.reward = REWARD
         self.action_space =  spaces.Discrete(8)
         self.observation_space = spaces.Tuple((


### PR DESCRIPTION
When starting the "Windy Gridworld with King’s Moves" environment I encountered a bug:

`AttributeError: 'KingWindyGridWorldEnv' object has no attribute 'observation'
`

This should fix it.